### PR TITLE
Removed unnecessary manifest attributes

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest package="com.zl.reik.dilatingdotsprogressbar" xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<application android:allowBackup="true" android:label="@string/app_name" android:supportsRtl="true">
+	<application android:label="@string/app_name">
 
 	</application>
 


### PR DESCRIPTION
The manifest merger fails when your app sets these attributes because they conflict with the ones in this library.
They are not needed for a library, so removing them is fine. Let the app define the final values.
